### PR TITLE
Quick release: 0.2.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.stimage
-version = 0.2.1.dev
+version = 0.2.2
 author = Michael Droettboom
 author-email = help@stsci.edu
 summary = Various image processing functions


### PR DESCRIPTION
Drop the `.dev` suffix in production.

(Yes, I am aware that I could simply remove `.dev` from `0.2.1`, however I'd rather see a traceable version change in Conda rather than a build revision bump.)