### PR TITLE
Replaces NPY_OWNDATA with NPY_ARRAY_OWNDATA

### DIFF
--- a/src/wrap/immatch/py_geomap.c
+++ b/src/wrap/immatch/py_geomap.c
@@ -331,7 +331,7 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
     dims = (npy_intp)noutput;
     output_array = PyArray_NewFromDescr(
             &PyArray_Type, dtype, 1, &dims, NULL, output,
-            NPY_OWNDATA, NULL);
+            NPY_ARRAY_OWNDATA, NULL);
     if (output_array == NULL) {
         goto exit;
     }

--- a/src/wrap/immatch/py_xyxymatch.c
+++ b/src/wrap/immatch/py_xyxymatch.c
@@ -150,7 +150,7 @@ py_xyxymatch(PyObject* self, PyObject* args, PyObject* kwds) {
     Py_DECREF(dtype_list);
     dims = (npy_intp)noutput;
     result = PyArray_NewFromDescr(
-            &PyArray_Type, dtype, 1, &dims, NULL, output, NPY_OWNDATA, NULL);
+            &PyArray_Type, dtype, 1, &dims, NULL, output, NPY_ARRAY_OWNDATA, NULL);
 
  exit:
 


### PR DESCRIPTION
```
stsci.stimage/src/wrap/immatch/py_xyxymatch.c has deprecated symbol NPY_OWNDATA:
        Line 153: &PyArray_Type, dtype, 1, &dims, NULL, output, NPY_OWNDATA, NULL);
        Replace with: NPY_ARRAY_OWNDATA

stsci.stimage/src/wrap/immatch/py_geomap.c has deprecated symbol NPY_OWNDATA:
        Line 334: NPY_OWNDATA, NULL);
        Replace with: NPY_ARRAY_OWNDATA
```
