### PR TITLE
Fix incompatible pointer types (second attempt)

### DIFF
--- a/src/wrap/immatch/py_geomap.c
+++ b/src/wrap/immatch/py_geomap.c
@@ -74,7 +74,7 @@ geomap_array_init() {
     
     o = PyArray_SimpleNew(1, &dims, NPY_DOUBLE);
     if (o != NULL) {
-        *((double*)PyArray_GETPTR1(o, 0)) = 0.0;
+        *((double*)PyArray_GETPTR1((PyArrayObject *) o, 0)) = 0.0;
     }
 
     return o;
@@ -266,7 +266,7 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
     if (input_array == NULL) {
         goto exit;
     }
-    if (PyArray_DIM(input_array, 1) != 2) {
+    if (PyArray_DIM((PyArrayObject *) input_array, 1) != 2) {
         PyErr_SetString(PyExc_TypeError, "input array must be an Nx2 array");
         goto exit;
     }
@@ -276,7 +276,7 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
     if (ref_array == NULL) {
         goto exit;
     }
-    if (PyArray_DIM(ref_array, 1) != 2) {
+    if (PyArray_DIM((PyArrayObject *) ref_array, 1) != 2) {
         PyErr_SetString(PyExc_TypeError, "ref array must be an Nx2 array");
         goto exit;
     }
@@ -289,8 +289,8 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
         goto exit;
     }
 
-    ninput = PyArray_DIM(input_array, 0);
-    nref = PyArray_DIM(ref_array, 0);
+    ninput = PyArray_DIM((PyArrayObject *) input_array, 0);
+    nref = PyArray_DIM((PyArrayObject *) ref_array, 0);
     noutput = MAX(ninput, nref);
     output = malloc(noutput * sizeof(geomap_output_t));
     if (output == NULL) {
@@ -299,8 +299,8 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
     }
 
     if (geomap(
-                ninput, (coord_t*)PyArray_DATA(input_array),
-                nref, (coord_t*)PyArray_DATA(ref_array),
+                ninput, (coord_t*)PyArray_DATA((PyArrayObject *) input_array),
+                nref, (coord_t*)PyArray_DATA((PyArrayObject *) ref_array),
                 &bbox, fit_geometry, surface_type,
                 xxorder, xyorder, yxorder, yyorder,
                 xxterms, yxterms,
@@ -347,7 +347,8 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
         dims = (size); \
         tmp = PyArray_SimpleNew(1, &dims, NPY_DOUBLE); \
         if (tmp == NULL) goto exit; \
-        for (i = 0; i < (size); ++i) ((double*)PyArray_DATA(tmp))[i] = (member)[i]; \
+        for (i = 0; i < (size); ++i) \
+            ((double*)PyArray_DATA((PyArrayObject *) tmp))[i] = (member)[i]; \
         PyObject_SetAttrString(fit_obj, (name), tmp); \
         Py_DECREF(tmp);
 

--- a/src/wrap/immatch/py_xyxymatch.c
+++ b/src/wrap/immatch/py_xyxymatch.c
@@ -93,7 +93,7 @@ py_xyxymatch(PyObject* self, PyObject* args, PyObject* kwds) {
     if (input_array == NULL) {
         goto exit;
     }
-    if (PyArray_DIM(input_array, 1) != 2) {
+    if (PyArray_DIM((PyArrayObject *) input_array, 1) != 2) {
         PyErr_SetString(PyExc_TypeError, "input array must be an Nx2 array");
         goto exit;
     }
@@ -103,7 +103,7 @@ py_xyxymatch(PyObject* self, PyObject* args, PyObject* kwds) {
     if (ref_array == NULL) {
         goto exit;
     }
-    if (PyArray_DIM(ref_array, 1) != 2) {
+    if (PyArray_DIM((PyArrayObject *) ref_array, 1) != 2) {
         PyErr_SetString(PyExc_TypeError, "ref array must be an Nx2 array");
         goto exit;
     }
@@ -116,15 +116,15 @@ py_xyxymatch(PyObject* self, PyObject* args, PyObject* kwds) {
         goto exit;
     }
 
-    noutput = PyArray_DIM(input_array, 0);
+    noutput = PyArray_DIM((PyArrayObject *) input_array, 0);
     output = malloc(noutput * sizeof(xyxymatch_output_t));
     if (output == NULL) {
         result = PyErr_NoMemory();
         goto exit;
     }
     if (xyxymatch(
-                PyArray_DIM(input_array, 0), (coord_t*)PyArray_DATA(input_array),
-                PyArray_DIM(ref_array, 0), (coord_t*)PyArray_DATA(ref_array),
+                PyArray_DIM((PyArrayObject *) input_array, 0), (coord_t*)PyArray_DATA((PyArrayObject *) input_array),
+                PyArray_DIM((PyArrayObject *) ref_array, 0), (coord_t*)PyArray_DATA((PyArrayObject *) ref_array),
                 &noutput, output,
                 &origin, &mag, &rotation, &ref_origin,
                 algorithm, tolerance, separation, nmatch, maxratio, nreject,

--- a/src/wrap/wrap_util.c
+++ b/src/wrap/wrap_util.c
@@ -57,7 +57,7 @@ to_coord_t(
         return -1;
     }
 
-    if (PyArray_DIM(array, 0) != 2) {
+    if (PyArray_DIM((PyArrayObject *) array, 0) != 2) {
         Py_DECREF(array);
         PyErr_Format(
                 PyExc_ValueError,
@@ -66,8 +66,8 @@ to_coord_t(
         return -1;
     }
 
-    c->x = *((double*)PyArray_GETPTR1(array, 0));
-    c->y = *((double*)PyArray_GETPTR1(array, 1));
+    c->x = *((double*)PyArray_GETPTR1((PyArrayObject *) array, 0));
+    c->y = *((double*)PyArray_GETPTR1((PyArrayObject *) array, 1));
 
     Py_DECREF(array);
 
@@ -86,8 +86,8 @@ from_coord_t(
         return -1;
     }
 
-    *((double*)PyArray_GETPTR1(*o, 0)) = c->x;
-    *((double*)PyArray_GETPTR1(*o, 1)) = c->y;
+    *((double*)PyArray_GETPTR1((PyArrayObject *) *o, 0)) = c->x;
+    *((double*)PyArray_GETPTR1((PyArrayObject *) *o, 1)) = c->y;
 
     return 0;
 }
@@ -110,10 +110,10 @@ to_bbox_t(
         return -1;
     }
 
-    if ((PyArray_NDIM(array) == 1 &&
-         PyArray_DIM(array, 0) != 4) ||
-        (PyArray_NDIM(array) == 2 &&
-         (PyArray_DIM(array, 0) != 2 || PyArray_DIM(array, 1) != 2))) {
+    if ((PyArray_NDIM((PyArrayObject *) array) == 1 &&
+         PyArray_DIM((PyArrayObject *) array, 0) != 4) ||
+        (PyArray_NDIM((PyArrayObject *) array) == 2 &&
+         (PyArray_DIM((PyArrayObject *) array, 0) != 2 || PyArray_DIM((PyArrayObject *) array, 1) != 2))) {
         PyErr_Format(
                 PyExc_ValueError,
                 "%s must be a length-4 or 2x2 sequence",
@@ -122,7 +122,7 @@ to_bbox_t(
         return -1;
     }
 
-    data = (double*)PyArray_DATA(array);
+    data = (double*)PyArray_DATA((PyArrayObject *) array);
     b->min.x = data[0];
     b->min.y = data[1];
     b->max.x = data[2];


### PR DESCRIPTION
* Casts `PyObject` to `PyArrayObject` in calls that use `PyArray_` macros