### PR TITLE
Fix segfault on unexpected argument values

### DIFF
--- a/src/wrap/immatch/py_geomap.c
+++ b/src/wrap/immatch/py_geomap.c
@@ -367,9 +367,7 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
     result = Py_BuildValue("OO", fit_obj, output_array);
 
  exit:
-    if (input_array) {
-        Py_DECREF(input_array);
-    }
+    Py_XDECREF(input_array);
     Py_XDECREF(ref_array);
     geomap_result_free(&fit);
     if (result == NULL) {

--- a/src/wrap/immatch/py_geomap.c
+++ b/src/wrap/immatch/py_geomap.c
@@ -367,9 +367,12 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
     result = Py_BuildValue("OO", fit_obj, output_array);
 
  exit:
-
-    Py_DECREF(input_array);
-    Py_DECREF(ref_array);
+    if (input_array) {
+        Py_DECREF(input_array);
+    }
+    if (ref_array) {
+        Py_DECREF(ref_array);
+    }
     geomap_result_free(&fit);
     if (result == NULL) {
         Py_XDECREF(output_array);

--- a/src/wrap/immatch/py_geomap.c
+++ b/src/wrap/immatch/py_geomap.c
@@ -370,9 +370,7 @@ py_geomap(PyObject* self, PyObject* args, PyObject* kwds) {
     if (input_array) {
         Py_DECREF(input_array);
     }
-    if (ref_array) {
-        Py_DECREF(ref_array);
-    }
+    Py_XDECREF(ref_array);
     geomap_result_free(&fit);
     if (result == NULL) {
         Py_XDECREF(output_array);

--- a/src/wrap/immatch/py_xyxymatch.c
+++ b/src/wrap/immatch/py_xyxymatch.c
@@ -153,9 +153,7 @@ py_xyxymatch(PyObject* self, PyObject* args, PyObject* kwds) {
             &PyArray_Type, dtype, 1, &dims, NULL, output, NPY_ARRAY_OWNDATA, NULL);
 
  exit:
-    if (input_array) {
-        Py_DECREF(input_array);
-    }
+    Py_XDECREF(input_array);
     if (ref_array) {
         Py_DECREF(ref_array);
     }

--- a/src/wrap/immatch/py_xyxymatch.c
+++ b/src/wrap/immatch/py_xyxymatch.c
@@ -153,9 +153,12 @@ py_xyxymatch(PyObject* self, PyObject* args, PyObject* kwds) {
             &PyArray_Type, dtype, 1, &dims, NULL, output, NPY_ARRAY_OWNDATA, NULL);
 
  exit:
-
-    Py_DECREF(input_array);
-    Py_DECREF(ref_array);
+    if (input_array) {
+        Py_DECREF(input_array);
+    }
+    if (ref_array) {
+        Py_DECREF(ref_array);
+    }
     if (result == NULL) {
         free(output);
     }

--- a/src/wrap/immatch/py_xyxymatch.c
+++ b/src/wrap/immatch/py_xyxymatch.c
@@ -154,9 +154,7 @@ py_xyxymatch(PyObject* self, PyObject* args, PyObject* kwds) {
 
  exit:
     Py_XDECREF(input_array);
-    if (ref_array) {
-        Py_DECREF(ref_array);
-    }
+    Py_XDECREF(ref_array);
     if (result == NULL) {
         free(output);
     }


### PR DESCRIPTION
* In functions py_geomap() and py_xyxymatch()

Original behavior:
```
$ gdb python
? r
>>> import stsci.stimage
>>> stsci.stimage.geomap([], [])

Thread 1 "python" received signal SIGSEGV, Segmentation fault.

py_geomap (self=<optimized out>, args=<optimized out>, kwds=<optimized out>) at src/wrap/immatch/py_geomap.c:372
372         Py_DECREF(input_array);
```

New behavior:

```python
>>> import stsci.stimage
>>> stsci.stimage.geomap([],[])
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    stsci.stimage.geomap([],[])
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/redacted/stsci.stimage/stsci/stimage/__init__.py", line 575, in geomap
    return _stimage.geomap(
           ~~~~~~~~~~~~~~~^
        input,
        ^^^^^^
    ...<10 lines>...
        maxiter,
        ^^^^^^^^
        reject)
        ^^^^^^^
ValueError: object of too small depth for desired array
>>>
```