### PR TITLE
TST: Fix CI and devdeps workflow logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
-        os: [ ubuntu-latest, macos-latest ]  # , windows-latest
-        numpy: [ '1.*' ]
         include:
           - python: '3.9'
             numpy: '1.20.*'
@@ -50,9 +47,12 @@ jobs:
             os: macos-latest
           - python: '3.13'
             numpy: '2.0.*'
+            os: ubuntu-latest
+          - python: '3.13'
+            numpy: '2.0.*'
             os: macos-latest
-          # - python: '3.12'
-          #   numpy: '1.26.*'
+          # - python: '3.13'
+          #   numpy: '2.0.*'
           #   os: windows-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
@@ -63,9 +63,10 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: pyproject.toml
-      - run: pip install -e ".[test]" "numpy==${{ matrix.numpy }}"
+      - run: pip install -e ".[test]"
       - run: python get_waf.py
       - run: python waf configure build
+      - run: pip install "numpy==${{ matrix.numpy }}"
       - run: pip freeze
       - run: pytest -rsv
   test_with_coverage:

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -8,6 +8,11 @@ on:
     tags:
       - '*'
   pull_request:
+    # We also want this workflow triggered if the label is added
+    # or present when PR is updated
+    types:
+      - synchronize
+      - labeled
   schedule:
     # Weekly Monday 7AM build
     - cron: "0 7 * * 1"
@@ -22,13 +27,13 @@ env:
 jobs:
   test_devdeps:
     if: (github.repository == 'spacetelescope/stsci.stimage' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
-    name: tests (Python ${{ matrix.python }}, numpy ${{ matrix.numpy }}, ${{ matrix.os }})
-    runs-on: ubuntu-latest
+    name: tests (Python ${{ matrix.python }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.9', '3.10', '3.11', '3.12' ]
-        os: [ ubuntu-latest, macos-latest ]
+        python: [ '3.13' ]
+        os: [ ubuntu-latest, macos-latest ]  # windows-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
@@ -38,7 +43,8 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependencies-path: pyproject.toml
-      - run: pip install -e ".[test]" "numpy>=2.0.0" --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      - run: pip install "numpy>=0.0.0" --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre -U
+      - run: pip install -e ".[test]"
       - run: python get_waf.py
       - run: python waf configure build
       - run: pip freeze


### PR DESCRIPTION
* Removed matrix settings that are not actually used.
* Added new job for Ubuntu in CI.
* Only installed pinned numpy in CI after building with numpy>=2 ABI.
* Added label trigger for devdeps job since it has label logic.
* Actually use specified OS for devdeps instead of mistakenly always running Ubuntu no matter what matrix says.
* Only run Python 3.13 on devdeps. It is overkill to loop through all Python version there. That is done in CI already.
* Force numpy-dev to install for devdeps. Otherwise, I don't see any point in having devdeps because no dev of anything is being installed actually.

These are the things originally noticed and fixed in #54 but unrelated to Windows support.