### PR TITLE
surface: increase size of vector and ncoeff arrays

### DIFF
--- a/src/surface/fit.c
+++ b/src/surface/fit.c
@@ -185,7 +185,7 @@ surface_fit_add_points(
             }
 
             vindex = vzp + k;
-            assert(vindex - s->vector < s->ncoeff);
+            assert(vindex - s->vector < s->ncoeff * s->ncoeff);
             *vindex += vector_dot_product(ncoord, bw, z);
             bbyp = byp;
             bbxp = bxp;

--- a/src/surface/surface.c
+++ b/src/surface/surface.c
@@ -134,9 +134,9 @@ surface_init(
     s->cholesky_fact =
         malloc_with_error(s->ncoeff * s->ncoeff * sizeof(double), error);
     if (s->cholesky_fact == NULL) goto fail;
-    s->vector = malloc_with_error(s->ncoeff * sizeof(double), error);
+    s->vector = malloc_with_error(s->ncoeff * s->ncoeff * sizeof(double), error);
     if (s->vector == NULL) goto fail;
-    s->coeff = malloc_with_error(s->ncoeff * sizeof(double), error);
+    s->coeff = malloc_with_error(s->ncoeff * s->ncoeff * sizeof(double), error);
     if (s->coeff == NULL) goto fail;
 
     if (surface_zero(s, error)) {


### PR DESCRIPTION
This addresses a `test_geomap` error reported >10 years ago