### PR TITLE
Use local xorder instead of s->xorder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - run: python waf configure build
       - run: pip install "numpy==${{ matrix.numpy }}"
       - run: pip freeze
-      - run: pytest -rsv
+      - run: pytest -vvv -rs
   test_with_coverage:
     name: run tests with coverage
     needs: [ test ]
@@ -86,7 +86,7 @@ jobs:
       - run: python get_waf.py
       - run: python waf configure build
       - run: pip freeze
-      - run: pytest -rsv --cov=./ --cov-report=xml --cov-report term-missing
+      - run: pytest -vvv -rs --cov=./ --cov-report=xml --cov-report term-missing
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
         with:
           files: ./coverage.xml

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -48,4 +48,4 @@ jobs:
       - run: python get_waf.py
       - run: python waf configure build
       - run: pip freeze
-      - run: pytest -rsv
+      - run: pytest -vvv -rs

--- a/src/surface/fit.c
+++ b/src/surface/fit.c
@@ -179,7 +179,7 @@ surface_fit_add_points(
 
         bxp = xbasis;
 
-        for (k = 1; k <= s->xorder; ++k) {
+        for (k = 1; k <= xorder; ++k) {
             for (i = 0; i < ncoord; ++i) {
                 bw[i] = byw[i] * bxp[i];
             }

--- a/test_c/test_c.py
+++ b/test_c/test_c.py
@@ -8,7 +8,7 @@ import pytest
 ROOT = os.path.relpath(os.path.join('build', 'test_c'))
 TESTS = [
     'test_cholesky',
-    # 'test_geomap',  # FIXME: died with Signals.SIGABRT 6
+    'test_geomap',
     'test_lintransform',
     'test_surface',
     'test_triangles',


### PR DESCRIPTION
This addresses the >10 year old failure in `test_geomap`.

The local `xorder` variable is modified by a switch statement at the end of each `yorder` iteration, but the nested `s->xorder` loop never _used_ `xorder`, so it would calculate a `vindex` that exceeded the upper bounds of the `vzp` array.
