### PR TITLE
A codecov token is now required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
       - run: pytest -vvv -rsv --cov=./ --cov-report=xml --cov-report term-missing
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
 


### PR DESCRIPTION
`master` is protected and requires a token in order to upload coverage data.