### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering :: Astronomy",
@@ -16,6 +15,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.14",
 ]
+license-files = ["LICENSE"]
 dynamic = [
     "version",
 ]
@@ -23,10 +23,6 @@ dynamic = [
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
-
-[project.license]
-file = "LICENSE"
-content-type = "text/plain"
 
 [project.urls]
 Tracker = "https://github.com/spacetelescope/stsci.stimage/issues"


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))